### PR TITLE
Fixed upvote/downvote in TagRecyclerViewAdapter 

### DIFF
--- a/app/src/main/java/edu/temple/templetag/HomeActivity.java
+++ b/app/src/main/java/edu/temple/templetag/HomeActivity.java
@@ -257,7 +257,6 @@ public class HomeActivity extends AppCompatActivity {
                     Log.d(TAG, "Tag document: " + documentChange.toString());
                     switch (documentChange.getType()) {
                         case ADDED:
-
                             // get tag downvoteCount
                             int parsedDownvoteCount = Integer.parseInt(documentChange.getDocument().getData().get("downvoteCount").toString());
 

--- a/app/src/main/java/edu/temple/templetag/adapters/TagRecyclerViewAdapter.java
+++ b/app/src/main/java/edu/temple/templetag/adapters/TagRecyclerViewAdapter.java
@@ -76,6 +76,8 @@ public class TagRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     public void onComplete(@NonNull Task<Void> task) {
                         if (task.isSuccessful()) {
                             Toast.makeText(context, "Tag Voted Up", Toast.LENGTH_SHORT).show();
+                            (Tags.get(position)).setmTagUpvoteCount(Tags.get(position).getmTagUpvoteCount()+1);
+                            notifyDataSetChanged();
                         }
                         else {
                             Toast.makeText(context, "Up Vote Failed", Toast.LENGTH_SHORT).show();
@@ -95,6 +97,8 @@ public class TagRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     public void onComplete(@NonNull Task<Void> task) {
                         if (task.isSuccessful()) {
                             Toast.makeText(context, "Tag Voted Down", Toast.LENGTH_SHORT).show();
+                            (Tags.get(position)).setmTagDownvoteCount(Tags.get(position).getmTagDownvoteCount()+1);
+                            notifyDataSetChanged();
                         }
                         else {
                             Toast.makeText(context, "Down Vote failed", Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
- Now when a user upvotes/downvotes a tag in HomeActivity then clicks on the tag to go to it's TagDetailActivity, those upvote/downvote numbers reflect the values in the database